### PR TITLE
+はアイコンを使う

### DIFF
--- a/resources/js/Components/Molecules/AddButton.tsx
+++ b/resources/js/Components/Molecules/AddButton.tsx
@@ -1,11 +1,19 @@
 import React from 'react'
+import AddOutlinedIcon from '@mui/icons-material/AddOutlined'
 
 type Props = {
     data: string
 }
 
 const AddButton: React.FC<Props> = ({ data }) => {
-    return <button className="my-3 text-gray-500">＋{data}を追加</button>
+    return (
+        <button className="my-3 text-gray-500 flex items-center justify-center">
+            <span>
+                <AddOutlinedIcon sx={{ verticalAlign: '-6px' }} />
+            </span>
+            <span>{data}を追加</span>
+        </button>
+    )
 }
 
 export default AddButton


### PR DESCRIPTION
### レビューNo.
Rev002

### レビュー内容
＋タスクを追加
上記のプラスですが、プログラミング的にはアイコンを使ったりして単なる文字列ではなく記号として埋め込んだほうが良いかなと。

### 対応内容
MUIのアイコンを導入しました。
レイアウトはflexのitems-centerで揃わなかったので、verticalAlign: '-6px'で無理やり揃えています。

### 参考サイト
- アイコン
https://mui.com/material-ui/material-icons/?theme=Outlined&query=plus
- レイアウト
https://qiita.com/yosaprog/items/4ce0384126be5dcc410d