### PR TITLE
toStringStatusなどはマジックナンバーを使わない

### DIFF
--- a/resources/js/Components/DeadlineOption.tsx
+++ b/resources/js/Components/DeadlineOption.tsx
@@ -8,11 +8,11 @@ const DeadlineOption: React.FC = () => {
 
     // 締切日を文字列に変換する
     const toStringDeadline = (num: number) => {
-        if (num === 1) {
+        if (num === DeadlineOptions.today) {
             return '今日'
-        } else if (num === 2) {
+        } else if (num === DeadlineOptions.threeDaysLater) {
             return '3日後'
-        } else if (num === 3) {
+        } else if (num === DeadlineOptions.oneWeekLater) {
             return '1週間後'
         }
     }

--- a/resources/js/Components/StatusOption.tsx
+++ b/resources/js/Components/StatusOption.tsx
@@ -21,9 +21,9 @@ const StatusOption: React.FC = () => {
     }
     // ステータスを文字列に変換する
     const toStringStatus = (num: number): string => {
-        if (num === 3) {
+        if (num === StatusOptions.completed) {
             return '完了'
-        } else if (num === 2) {
+        } else if (num === StatusOptions.working) {
             return '進行中'
         } else {
             return '未着手'

--- a/resources/js/Pages/Admin/MyTask.tsx
+++ b/resources/js/Pages/Admin/MyTask.tsx
@@ -16,6 +16,7 @@ import StatusOption from '@/Components/StatusOption'
 import DeadlineOption from '@/Components/DeadlineOption'
 import AddButton from '@/Components/Molecules/AddButton'
 import { format } from 'date-fns/format'
+import { PriorityOptions } from '@/consts/IndexConsts'
 
 export default function MyTask({ auth }: PageProps) {
     const [isStop, setIsStop] = useState<boolean>(true) // タスクが停止中かどうか
@@ -37,9 +38,9 @@ export default function MyTask({ auth }: PageProps) {
 
     // 優先度を文字列に変換する
     const toStringPriority = (num: number): string => {
-        if (num === 1) {
+        if (num === PriorityOptions.high) {
             return '高'
-        } else if (num === 2) {
+        } else if (num === PriorityOptions.middle) {
             return '中'
         } else {
             return '低'


### PR DESCRIPTION
### レビューNo.
Rev003

### レビュー内容
toStringStatusなど3,2,1としているかと思いますが、できれば'completed', 'doing', 'ready'とかでステータスコードがパッと見分かる方が制作しやすいしエラーも起きにくいかなと。

### 対応内容
定義していた定数を使いました。