### PR TITLE
elseは使わず1ならnum === 1 で明記する

### DIFF
--- a/resources/js/Components/DeadlineOption.tsx
+++ b/resources/js/Components/DeadlineOption.tsx
@@ -7,13 +7,15 @@ const DeadlineOption: React.FC = () => {
     const [selectedDeadlineIds, setSelectedDeadlineIds] = useState<number[]>([]) // 選択中の締切日ID
 
     // 締切日を文字列に変換する
-    const toStringDeadline = (num: number) => {
+    const toStringDeadline = (num: number): string => {
         if (num === DeadlineOptions.today) {
             return '今日'
         } else if (num === DeadlineOptions.threeDaysLater) {
             return '3日後'
         } else if (num === DeadlineOptions.oneWeekLater) {
             return '1週間後'
+        } else {
+            throw new Error('不正な値を検出: DeadlineOptions=' + num)
         }
     }
 

--- a/resources/js/Components/StatusOption.tsx
+++ b/resources/js/Components/StatusOption.tsx
@@ -25,8 +25,10 @@ const StatusOption: React.FC = () => {
             return '完了'
         } else if (num === StatusOptions.working) {
             return '進行中'
-        } else {
+        } else if (num === StatusOptions.notStarted) {
             return '未着手'
+        } else {
+            throw new Error('不正な値を検出: StatusOptions=' + num)
         }
     }
 

--- a/resources/js/Pages/Admin/MyTask.tsx
+++ b/resources/js/Pages/Admin/MyTask.tsx
@@ -42,8 +42,10 @@ export default function MyTask({ auth }: PageProps) {
             return '高'
         } else if (num === PriorityOptions.middle) {
             return '中'
-        } else {
+        } else if (num === PriorityOptions.low) {
             return '低'
+        } else {
+            throw new Error('不正な値を検出: PriorityOptions=' + num)
         }
     }
 


### PR DESCRIPTION
### レビューNo.
Rev004

### レビュー内容
elseは使わず1ならnum === 1 で明記するのが無難です。

### 対応内容
TypeScriptで戻り値をstringとしているので、最終的に何もなかった場合のreturnがないと以下のエラーになってしまうのでelseで書いていましたが、ifを通らないのならエラーをスローすることで解決できました。