### PR TITLE
TextFieldをInputへ

### DIFF
--- a/resources/js/Components/Defaults/Checkbox.tsx
+++ b/resources/js/Components/Defaults/Checkbox.tsx
@@ -1,14 +1,17 @@
-import { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes } from 'react'
 
-export default function Checkbox({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+export default function Checkbox({
+    className = '',
+    ...props
+}: InputHTMLAttributes<HTMLInputElement>) {
     return (
         <input
             {...props}
             type="checkbox"
             className={
-                'rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500 ' +
+                'rounded border-gray-300 text-sky-500 shadow-sm focus:ring-0 ' +
                 className
             }
         />
-    );
+    )
 }

--- a/resources/js/Components/Defaults/InputLabel.tsx
+++ b/resources/js/Components/Defaults/InputLabel.tsx
@@ -1,9 +1,17 @@
-import { LabelHTMLAttributes } from 'react';
+import { LabelHTMLAttributes } from 'react'
 
-export default function InputLabel({ value, className = '', children, ...props }: LabelHTMLAttributes<HTMLLabelElement> & { value?: string }) {
+export default function InputLabel({
+    value,
+    className = '',
+    children,
+    ...props
+}: LabelHTMLAttributes<HTMLLabelElement> & { value?: string }) {
     return (
-        <label {...props} className={`block font-medium text-sm text-gray-700 ` + className}>
+        <label
+            {...props}
+            className={className}
+        >
             {value ? value : children}
         </label>
-    );
+    )
 }

--- a/resources/js/Components/Defaults/TextInput.tsx
+++ b/resources/js/Components/Defaults/TextInput.tsx
@@ -1,30 +1,41 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef, InputHTMLAttributes } from 'react';
+import {
+    forwardRef,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    InputHTMLAttributes,
+} from 'react'
 
 export default forwardRef(function TextInput(
-    { type = 'text', className = '', isFocused = false, ...props }: InputHTMLAttributes<HTMLInputElement> & { isFocused?: boolean },
+    {
+        type = 'text',
+        className = '',
+        isFocused = false,
+        ...props
+    }: InputHTMLAttributes<HTMLInputElement> & { isFocused?: boolean },
     ref
 ) {
-    const localRef = useRef<HTMLInputElement>(null);
+    const localRef = useRef<HTMLInputElement>(null)
 
     useImperativeHandle(ref, () => ({
         focus: () => localRef.current?.focus(),
-    }));
+    }))
 
     useEffect(() => {
         if (isFocused) {
-            localRef.current?.focus();
+            localRef.current?.focus()
         }
-    }, []);
+    }, [])
 
     return (
         <input
             {...props}
             type={type}
             className={
-                'border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm ' +
+                'border-gray-300 focus:border-blue-500 focus:ring-blue-500 rounded-md shadow-sm ' +
                 className
             }
             ref={localRef}
         />
-    );
-});
+    )
+})

--- a/resources/js/Pages/Admin/MyTask.tsx
+++ b/resources/js/Pages/Admin/MyTask.tsx
@@ -3,7 +3,7 @@ import { Head } from '@inertiajs/react'
 import { PageProps } from '@/types'
 import PlayCircleOutlinedIcon from '@mui/icons-material/PlayCircleOutlined'
 import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined'
-import Checkbox from '@mui/material/Checkbox'
+import Checkbox from '@/Components/Defaults/Checkbox'
 import React, { useState } from 'react'
 import { Button } from '@mui/base'
 import {

--- a/resources/js/Pages/Admin/Project.tsx
+++ b/resources/js/Pages/Admin/Project.tsx
@@ -3,7 +3,6 @@ import { Head } from '@inertiajs/react'
 import { PageProps } from '@/types'
 import PlayCircleOutlinedIcon from '@mui/icons-material/PlayCircleOutlined'
 import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined'
-import Checkbox from '@mui/material/Checkbox'
 import React, { useState } from 'react'
 import { Button } from '@mui/base'
 import {
@@ -22,6 +21,9 @@ import FormControlLabel from '@mui/material/FormControlLabel'
 import Typography from '@mui/material/Typography'
 import SortButton from '@/Components/Molecules/SortButton'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import TextInput from '@/Components/Defaults/TextInput'
+import Checkbox from '@/Components/Defaults/Checkbox'
+import InputLabel from '@/Components/Defaults/InputLabel'
 
 const Project: React.FC<PageProps> = ({ auth }) => {
     const [isStop, setIsStop] = useState<boolean>(true) // タスクが停止中かどうか
@@ -78,41 +80,23 @@ const Project: React.FC<PageProps> = ({ auth }) => {
                         </p>
                     </div>
                     <div className="flex flex-col items-center justify-center my-3">
-                        <div className="my-1">
-                            {/* <TextField
-                                className="bg-white rounded-md"
-                                id="project-name"
-                                label="プロジェクト名で絞り込む"
-                                variant="outlined"
-                                size="small"
-                                InputLabelProps={{
-                                    style: { fontSize: '13px' },
-                                    shrink: false,
-                                }}
-                            /> */}
-                        </div>
-                        <div className="my-1">
-                            <TextField
-                                className="bg-white rounded-md"
-                                id="client-name"
-                                label="取引先名で絞り込む"
-                                variant="outlined"
-                                size="small"
-                                InputLabelProps={{
-                                    style: { fontSize: '13px' },
-                                    shrink: false,
-                                }}
+                        <div className="my-1 w-11/12">
+                            <TextInput
+                                className="text-[13px] w-full"
+                                placeholder="プロジェクト名で絞り込む"
                             />
                         </div>
-                        <div>
-                            <FormControlLabel
-                                control={<Checkbox />}
-                                label={
-                                    <Typography sx={{ fontSize: 13 }}>
-                                        完了プロジェクトを表示
-                                    </Typography>
-                                }
+                        <div className="my-1 w-11/12">
+                            <TextInput
+                                className="text-[13px] w-full"
+                                placeholder="取引先名で絞り込む"
                             />
+                        </div>
+                        <div className="flex items-center w-11/12 mt-1">
+                            <InputLabel className="block text-sm text-gray-500">
+                                <Checkbox className="mr-2" />
+                                完了プロジェクトを表示
+                            </InputLabel>
                         </div>
                         <div className="text-[13px] text-gray-500 mt-3 mb-1">
                             <SortButton


### PR DESCRIPTION
### タスクNo.
Task002-01

### 画面
プロジェクト（タスク一覧）画面

### 対応内容
「Task002レイアウト作成」の子タスク
TextFieldをInputへ
デフォルトでプロジェクトに入っていたコンポーネントを少しカスタマイズして利用しました。

### 参考サイト
■ チェックボックスの周りの線を消す方法
- https://github.com/tailwindlabs/tailwindcss/discussions/9597
- https://tailwindcss.com/docs/ring-width
